### PR TITLE
Use fileName instead of name for getName

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -201,7 +201,7 @@ export default (options: Options = {}): Plugin => {
           const { dir, name } = path.parse(chunk.fileName);
           return dir ? `${dir}/${name}` : name;
         }
-        return chunk.name;
+        return path.parse(chunk.fileName).name;
       };
 
       const getImports = (chunk: OutputChunk): string[] => {


### PR DESCRIPTION
Hey!

A suggestion that would solve one problem we are running into using this library. We `mode: extract` scss that is code-splitted like the js chunks, but some of these chunks gets named "index.[hash]" (or potentially any other duplicated names) due to how rollup names chunks – which makes it hard to identify what chunk it belongs to. I havent found any other way of avoiding this, other than renaming the culprits – but that would still be error prone.

Using this code, the output would be the content hashed `index.[hash]`, which again would give `index.[jshash].[csshash].css`, but then it would atleast be uniquely identifiable.

Not sure if you have any other suggestions in order to solve this?