### PR TITLE
build: cssnano update

### DIFF
--- a/__tests__/__snapshots__/index.test.ts.snap
+++ b/__tests__/__snapshots__/index.test.ts.snap
@@ -2980,13 +2980,13 @@ injector_3b481dac(css,{});
 var css$1 = \\".bar{color:red}\\";
 injector_3b481dac(css$1,{});
 
-var css$2 = \\".stylus{color:red;background:red}\\";
+var css$2 = \\".stylus{background:red;color:red}\\";
 injector_3b481dac(css$2,{});
 
 var css$3 = \\".pcss{color:red}\\";
 injector_3b481dac(css$3,{});
 
-var css$4 = \\".sass{width:30%;color:red}\\";
+var css$4 = \\".sass{color:red;width:30%}\\";
 injector_3b481dac(css$4,{});
 
 var css$5 = \\".less{color:#6c94be}\\";

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@rollup/pluginutils": "^4.1.0",
     "@types/cssnano": "^4.0.0",
     "cosmiconfig": "^7.0.0",
-    "cssnano": "^4.1.10",
+    "cssnano": "^5.0.0",
     "fs-extra": "^9.1.0",
     "icss-utils": "^5.1.0",
     "mime-types": "^2.1.28",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,7 +2,7 @@ dependencies:
   '@rollup/pluginutils': 4.1.0_rollup@2.38.1
   '@types/cssnano': 4.0.0
   cosmiconfig: 7.0.0
-  cssnano: 4.1.10
+  cssnano: 5.0.0_postcss@8.2.4
   fs-extra: 9.1.0
   icss-utils: 5.1.0_postcss@8.2.4
   mime-types: 2.1.28
@@ -1790,6 +1790,12 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+  /@trysound/sax/0.1.1:
+    dev: false
+    engines:
+      node: '>=10.13.0'
+    resolution:
+      integrity: sha512-Z6DoceYb/1xSg5+e+ZlPZ9v0N16ZvZ+wYMraFue4HYrE4ttONKtsvruIRf6t9TBR0YvSOfi1hUU0fJfBLCDYow==
   /@types/babel__core/7.1.12:
     dependencies:
       '@babel/parser': 7.12.11
@@ -1899,10 +1905,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-6gOkRe7OIioWAXfnO/2lFiv+SJichKVSys1mSsgyrYHSEjk8Ctv4tSR/Odvnu+HWlH2C8j53dahU03XmQdd5fA==
-  /@types/q/1.5.4:
-    dev: false
-    resolution:
-      integrity: sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
   /@types/resolve/1.17.1:
     dependencies:
       '@types/node': 14.14.22
@@ -2186,7 +2188,6 @@ packages:
   /ansi-styles/4.3.0:
     dependencies:
       color-convert: 2.0.1
-    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -2225,6 +2226,7 @@ packages:
   /argparse/1.0.10:
     dependencies:
       sprintf-js: 1.0.3
+    dev: true
     resolution:
       integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   /argv-formatter/1.0.0:
@@ -2633,30 +2635,9 @@ packages:
     dependencies:
       function-bind: 1.1.1
       get-intrinsic: 1.1.0
+    dev: true
     resolution:
       integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
-  /caller-callsite/2.0.0:
-    dependencies:
-      callsites: 2.0.0
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=
-  /caller-path/2.0.0:
-    dependencies:
-      caller-callsite: 2.0.0
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=
-  /callsites/2.0.0:
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=
   /callsites/3.1.0:
     engines:
       node: '>=6'
@@ -2756,7 +2737,6 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-    dev: true
     engines:
       node: '>=10'
     resolution:
@@ -2891,16 +2871,6 @@ packages:
       node: '>= 0.12.0'
     resolution:
       integrity: sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
-  /coa/2.0.2:
-    dependencies:
-      '@types/q': 1.5.4
-      chalk: 2.4.2
-      q: 1.5.1
-    dev: false
-    engines:
-      node: '>= 4.0'
-    resolution:
-      integrity: sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==
   /code-point-at/1.1.0:
     dev: true
     engines:
@@ -2928,7 +2898,6 @@ packages:
   /color-convert/2.0.1:
     dependencies:
       color-name: 1.1.4
-    dev: true
     engines:
       node: '>=7.0.0'
     resolution:
@@ -2980,6 +2949,12 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
+  /commander/7.2.0:
+    dev: false
+    engines:
+      node: '>= 10'
+    resolution:
+      integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
   /commondir/1.0.1:
     dev: true
     resolution:
@@ -3104,17 +3079,6 @@ packages:
     dev: true
     resolution:
       integrity: sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
-  /cosmiconfig/5.2.1:
-    dependencies:
-      import-fresh: 2.0.0
-      is-directory: 0.3.1
-      js-yaml: 3.14.1
-      parse-json: 4.0.0
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
   /cosmiconfig/7.0.0:
     dependencies:
       '@types/parse-json': 4.0.0
@@ -3158,43 +3122,37 @@ packages:
     dev: false
     resolution:
       integrity: sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=
-  /css-declaration-sorter/4.0.1:
+  /css-color-names/1.0.1:
+    dev: false
+    resolution:
+      integrity: sha512-/loXYOch1qU1biStIFsHH8SxTmOseh1IJqFvy8IujXOm1h+QjUdDhkzOrR5HG8K8mlxREj0yfi8ewCHx0eMxzA==
+  /css-declaration-sorter/6.0.0_postcss@8.2.4:
     dependencies:
-      postcss: 7.0.35
+      postcss: 8.2.4
       timsort: 0.3.0
     dev: false
     engines:
-      node: '>4'
+      node: '>= 10'
+    peerDependencies:
+      postcss: ^8.0.9
     resolution:
-      integrity: sha512-BcxQSKTSEEQUftYpBVnsH4SF05NTuBokb19/sBt6asXGKZ/6VP7PLG1CBCkFDYOnhXhPh0jMhO6xZ71oYHXHBA==
+      integrity: sha512-S0TE4E0ha5+tBHdLWPc5n+S8E4dFBS5xScPvgHkLNZwWvX4ISoFGhGeerLC9uS1cKA/sC+K2wHq6qEbcagT/fg==
   /css-parse/2.0.0:
     dependencies:
       css: 2.2.4
     dev: true
     resolution:
       integrity: sha1-pGjuZnwW2BzPBcWMONKpfHgNv9Q=
-  /css-select-base-adapter/0.1.1:
-    dev: false
-    resolution:
-      integrity: sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==
-  /css-select/2.1.0:
+  /css-select/3.1.2:
     dependencies:
       boolbase: 1.0.0
-      css-what: 3.4.2
-      domutils: 1.7.0
-      nth-check: 1.0.2
+      css-what: 4.0.0
+      domhandler: 4.1.0
+      domutils: 2.5.2
+      nth-check: 2.0.0
     dev: false
     resolution:
-      integrity: sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==
-  /css-tree/1.0.0-alpha.37:
-    dependencies:
-      mdn-data: 2.0.4
-      source-map: 0.6.1
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    resolution:
-      integrity: sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==
+      integrity: sha512-qmss1EihSuBNWNNhHjxzxSfJoFBM/lERB/Q4EnsJQQC62R2evJDW481091oAdOr9uh46/0n4nrg0It5cAnj1RA==
   /css-tree/1.1.2:
     dependencies:
       mdn-data: 2.0.14
@@ -3204,12 +3162,12 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-wCoWush5Aeo48GLhfHPbmvZs59Z+M7k5+B1xDnXbdWNcEF423DoFdqSWE0PM5aNk5nI5cp1q7ms36zGApY/sKQ==
-  /css-what/3.4.2:
+  /css-what/4.0.0:
     dev: false
     engines:
       node: '>= 6'
     resolution:
-      integrity: sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==
+      integrity: sha512-teijzG7kwYfNVsUh2H/YN62xW3KK9YhXEgSlbxMlcyjPNvdKJqFx5lrwlJgoFP1ZHlB89iGDlo/JyshKeRhv5A==
   /css/2.2.4:
     dependencies:
       inherits: 2.0.4
@@ -3226,80 +3184,70 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
-  /cssnano-preset-default/4.0.7:
+  /cssnano-preset-default/5.0.0_postcss@8.2.4:
     dependencies:
-      css-declaration-sorter: 4.0.1
-      cssnano-util-raw-cache: 4.0.1
-      postcss: 7.0.35
-      postcss-calc: 7.0.5
-      postcss-colormin: 4.0.3
-      postcss-convert-values: 4.0.1
-      postcss-discard-comments: 4.0.2
-      postcss-discard-duplicates: 4.0.2
-      postcss-discard-empty: 4.0.1
-      postcss-discard-overridden: 4.0.1
-      postcss-merge-longhand: 4.0.11
-      postcss-merge-rules: 4.0.3
-      postcss-minify-font-values: 4.0.2
-      postcss-minify-gradients: 4.0.2
-      postcss-minify-params: 4.0.2
-      postcss-minify-selectors: 4.0.2
-      postcss-normalize-charset: 4.0.1
-      postcss-normalize-display-values: 4.0.2
-      postcss-normalize-positions: 4.0.2
-      postcss-normalize-repeat-style: 4.0.2
-      postcss-normalize-string: 4.0.2
-      postcss-normalize-timing-functions: 4.0.2
-      postcss-normalize-unicode: 4.0.1
-      postcss-normalize-url: 4.0.1
-      postcss-normalize-whitespace: 4.0.2
-      postcss-ordered-values: 4.1.2
-      postcss-reduce-initial: 4.0.3
-      postcss-reduce-transforms: 4.0.2
-      postcss-svgo: 4.0.2
-      postcss-unique-selectors: 4.0.1
+      css-declaration-sorter: 6.0.0_postcss@8.2.4
+      cssnano-utils: 2.0.0_postcss@8.2.4
+      postcss: 8.2.4
+      postcss-calc: 8.0.0_postcss@8.2.4
+      postcss-colormin: 5.0.0_postcss@8.2.4
+      postcss-convert-values: 5.0.0_postcss@8.2.4
+      postcss-discard-comments: 5.0.0_postcss@8.2.4
+      postcss-discard-duplicates: 5.0.0_postcss@8.2.4
+      postcss-discard-empty: 5.0.0_postcss@8.2.4
+      postcss-discard-overridden: 5.0.0_postcss@8.2.4
+      postcss-merge-longhand: 5.0.0_postcss@8.2.4
+      postcss-merge-rules: 5.0.0_postcss@8.2.4
+      postcss-minify-font-values: 5.0.0_postcss@8.2.4
+      postcss-minify-gradients: 5.0.0_postcss@8.2.4
+      postcss-minify-params: 5.0.0_postcss@8.2.4
+      postcss-minify-selectors: 5.0.0_postcss@8.2.4
+      postcss-normalize-charset: 5.0.0_postcss@8.2.4
+      postcss-normalize-display-values: 5.0.0_postcss@8.2.4
+      postcss-normalize-positions: 5.0.0_postcss@8.2.4
+      postcss-normalize-repeat-style: 5.0.0_postcss@8.2.4
+      postcss-normalize-string: 5.0.0_postcss@8.2.4
+      postcss-normalize-timing-functions: 5.0.0_postcss@8.2.4
+      postcss-normalize-unicode: 5.0.0_postcss@8.2.4
+      postcss-normalize-url: 5.0.0_postcss@8.2.4
+      postcss-normalize-whitespace: 5.0.0_postcss@8.2.4
+      postcss-ordered-values: 5.0.0_postcss@8.2.4
+      postcss-reduce-initial: 5.0.0_postcss@8.2.4
+      postcss-reduce-transforms: 5.0.0_postcss@8.2.4
+      postcss-svgo: 5.0.0_postcss@8.2.4
+      postcss-unique-selectors: 5.0.0_postcss@8.2.4
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-x0YHHx2h6p0fCl1zY9L9roD7rnlltugGu7zXSKQx6k2rYw0Hi3IqxcoAGF7u9Q5w1nt7vK0ulxV8Lo+EvllGsA==
-  /cssnano-util-get-arguments/4.0.0:
-    dev: false
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha1-7ToIKZ8h11dBsg87gfGU7UnMFQ8=
-  /cssnano-util-get-match/4.0.0:
-    dev: false
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha1-wOTKB/U4a7F+xeUiULT1lhNlFW0=
-  /cssnano-util-raw-cache/4.0.1:
+      integrity: sha512-zsLppqF7PxY6Tk+ghVx8djf4o1jIOu2GNufqy9lMxldt7gGpSy3FQ6jn7FCd5DZWCaBa7A/1/HVh8CK3BdFSJg==
+  /cssnano-utils/2.0.0_postcss@8.2.4:
     dependencies:
-      postcss: 7.0.35
+      postcss: 8.2.4
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-qLuYtWK2b2Dy55I8ZX3ky1Z16WYsx544Q0UWViebptpwn/xDBmog2TLg4f+DBMg1rJ6JDWtn96WHbOKDWt1WQA==
-  /cssnano-util-same-parent/4.0.1:
-    dev: false
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-WcKx5OY+KoSIAxBW6UBBRay1U6vkYheCdjyVNDm85zt5K9mHoGOfsOsqIszfAqrQQFIIKgjh2+FDgIj/zsl21Q==
-  /cssnano/4.1.10:
+      integrity: sha512-xvxmTszdrvSyTACdPe8VU5J6p4sm3egpgw54dILvNqt5eBUv6TFjACLhSxtRuEsxYrgy8uDy269YjScO5aKbGA==
+  /cssnano/5.0.0_postcss@8.2.4:
     dependencies:
-      cosmiconfig: 5.2.1
-      cssnano-preset-default: 4.0.7
+      cosmiconfig: 7.0.0
+      cssnano-preset-default: 5.0.0_postcss@8.2.4
       is-resolvable: 1.1.0
-      postcss: 7.0.35
+      opencollective-postinstall: 2.0.3
+      postcss: 8.2.4
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
+    requiresBuild: true
     resolution:
-      integrity: sha512-5wny+F6H4/8RgNlaqab4ktc3e0/blKutmq8yNlBFXA//nSFFAqAngjNVRzUvCgYROULmZZUoosL/KSoZo5aUaQ==
+      integrity: sha512-beaqJEU9aI0B2PpKWXy+UJdtw+Q2J2c2f2nHVphL/gb2wvkuQV+Zxf5Q5SsNXiPUb9Djo/+ja+UOelQWhHnVow==
   /csso/4.2.0:
     dependencies:
       css-tree: 1.1.2
@@ -3439,6 +3387,7 @@ packages:
   /define-properties/1.1.3:
     dependencies:
       object-keys: 1.1.1
+    dev: true
     engines:
       node: '>= 0.4'
     resolution:
@@ -3534,21 +3483,18 @@ packages:
       node: '>=6.0.0'
     resolution:
       integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
-  /dom-serializer/0.2.2:
+  /dom-serializer/1.3.1:
     dependencies:
-      domelementtype: 2.1.0
+      domelementtype: 2.2.0
+      domhandler: 4.1.0
       entities: 2.2.0
     dev: false
     resolution:
-      integrity: sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
-  /domelementtype/1.3.1:
+      integrity: sha512-Pv2ZluG5ife96udGgEDovOOOA5UELkltfJpnIExPrAk1LTvecolUGn6lIaoLh86d83GiB86CjzciMd9BuRB71Q==
+  /domelementtype/2.2.0:
     dev: false
     resolution:
-      integrity: sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
-  /domelementtype/2.1.0:
-    dev: false
-    resolution:
-      integrity: sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==
+      integrity: sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
   /domexception/2.0.1:
     dependencies:
       webidl-conversions: 5.0.0
@@ -3557,13 +3503,22 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==
-  /domutils/1.7.0:
+  /domhandler/4.1.0:
     dependencies:
-      dom-serializer: 0.2.2
-      domelementtype: 1.3.1
+      domelementtype: 2.2.0
+    dev: false
+    engines:
+      node: '>= 4'
+    resolution:
+      integrity: sha512-/6/kmsGlMY4Tup/nGVutdrK9yQi4YjWVcVeoQmixpzjOUK1U7pQkvAPHBJeUxOgxF0J8f8lwCJSlCfD0V4CMGQ==
+  /domutils/2.5.2:
+    dependencies:
+      dom-serializer: 1.3.1
+      domelementtype: 2.2.0
+      domhandler: 4.1.0
     dev: false
     resolution:
-      integrity: sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==
+      integrity: sha512-MHTthCb1zj8f1GVfRpeZUbohQf/HdBos0oX5gZcQFepOZPLLRyj6Wn7XS7EMnY7CVpwv8863u2vyE83Hfu28HQ==
   /dot-prop/5.3.0:
     dependencies:
       is-obj: 2.0.0
@@ -3651,24 +3606,6 @@ packages:
       is-arrayish: 0.2.1
     resolution:
       integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
-  /es-abstract/1.17.7:
-    dependencies:
-      es-to-primitive: 1.2.1
-      function-bind: 1.1.1
-      has: 1.0.3
-      has-symbols: 1.0.1
-      is-callable: 1.2.2
-      is-regex: 1.1.1
-      object-inspect: 1.9.0
-      object-keys: 1.1.1
-      object.assign: 4.1.2
-      string.prototype.trimend: 1.0.3
-      string.prototype.trimstart: 1.0.3
-    dev: false
-    engines:
-      node: '>= 0.4'
-    resolution:
-      integrity: sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==
   /es-abstract/1.18.0-next.2:
     dependencies:
       call-bind: 1.0.2
@@ -3685,6 +3622,7 @@ packages:
       object.assign: 4.1.2
       string.prototype.trimend: 1.0.3
       string.prototype.trimstart: 1.0.3
+    dev: true
     engines:
       node: '>= 0.4'
     resolution:
@@ -3694,6 +3632,7 @@ packages:
       is-callable: 1.2.2
       is-date-object: 1.0.2
       is-symbol: 1.0.3
+    dev: true
     engines:
       node: '>= 0.4'
     resolution:
@@ -3935,6 +3874,7 @@ packages:
     resolution:
       integrity: sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==
   /esprima/4.0.1:
+    dev: true
     engines:
       node: '>=4'
     hasBin: true
@@ -4443,6 +4383,7 @@ packages:
       function-bind: 1.1.1
       has: 1.0.3
       has-symbols: 1.0.1
+    dev: true
     resolution:
       integrity: sha512-M11rgtQp5GZMZzDL7jLTNxbDfurpzuau5uqRWDPvlHjfvg3TdScAZo96GLvhMjImrmR8uAt0FS2RLoMrfWGKlg==
   /get-own-enumerable-property-symbols/3.0.2:
@@ -4674,12 +4615,12 @@ packages:
     resolution:
       integrity: sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
   /has-flag/4.0.0:
-    dev: true
     engines:
       node: '>=8'
     resolution:
       integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
   /has-symbols/1.0.1:
+    dev: true
     engines:
       node: '>= 0.4'
     resolution:
@@ -4760,10 +4701,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-wc56MWjIxmFAM6S194d/OyJfnDg=
-  /html-comment-regex/1.1.2:
-    dev: false
-    resolution:
-      integrity: sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ==
   /html-encoding-sniffer/2.0.1:
     dependencies:
       whatwg-encoding: 1.0.5
@@ -4884,15 +4821,6 @@ packages:
     optional: true
     resolution:
       integrity: sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=
-  /import-fresh/2.0.0:
-    dependencies:
-      caller-path: 2.0.0
-      resolve-from: 3.0.0
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha1-2BNVwVYS04bGH53dOSLUMEgipUY=
   /import-fresh/3.3.0:
     dependencies:
       parent-module: 1.0.1
@@ -5007,12 +4935,12 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
-  /is-absolute-url/2.1.0:
+  /is-absolute-url/3.0.3:
     dev: false
     engines:
-      node: '>=0.10.0'
+      node: '>=8'
     resolution:
-      integrity: sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=
+      integrity: sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==
   /is-accessor-descriptor/0.1.6:
     dependencies:
       kind-of: 3.2.2
@@ -5049,6 +4977,7 @@ packages:
     resolution:
       integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
   /is-callable/1.2.2:
+    dev: true
     engines:
       node: '>= 0.4'
     resolution:
@@ -5093,6 +5022,7 @@ packages:
     resolution:
       integrity: sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==
   /is-date-object/1.0.2:
+    dev: true
     engines:
       node: '>= 0.4'
     resolution:
@@ -5117,12 +5047,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==
-  /is-directory/0.3.1:
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
   /is-docker/2.1.1:
     dev: true
     engines:
@@ -5196,6 +5120,7 @@ packages:
     resolution:
       integrity: sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=
   /is-negative-zero/2.0.1:
+    dev: true
     engines:
       node: '>= 0.4'
     resolution:
@@ -5270,6 +5195,7 @@ packages:
   /is-regex/1.1.1:
     dependencies:
       has-symbols: 1.0.1
+    dev: true
     engines:
       node: '>= 0.4'
     resolution:
@@ -5302,17 +5228,10 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==
-  /is-svg/3.0.0:
-    dependencies:
-      html-comment-regex: 1.1.2
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==
   /is-symbol/1.0.3:
     dependencies:
       has-symbols: 1.0.1
+    dev: true
     engines:
       node: '>= 0.4'
     resolution:
@@ -5903,6 +5822,7 @@ packages:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
+    dev: true
     hasBin: true
     resolution:
       integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -5961,6 +5881,7 @@ packages:
     resolution:
       integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
   /json-parse-better-errors/1.0.2:
+    dev: true
     resolution:
       integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
   /json-parse-even-better-errors/2.3.1:
@@ -6408,10 +6329,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==
-  /mdn-data/2.0.4:
-    dev: false
-    resolution:
-      integrity: sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==
   /meow/3.7.0:
     dependencies:
       camelcase-keys: 2.1.0
@@ -6542,6 +6459,7 @@ packages:
     resolution:
       integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==
   /minimist/1.2.5:
+    dev: true
     resolution:
       integrity: sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
   /minipass/3.1.3:
@@ -6577,6 +6495,7 @@ packages:
   /mkdirp/0.5.5:
     dependencies:
       minimist: 1.2.5
+    dev: true
     hasBin: true
     resolution:
       integrity: sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -6816,12 +6735,12 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=
-  /normalize-url/3.3.0:
+  /normalize-url/4.5.0:
     dev: false
     engines:
-      node: '>=6'
+      node: '>=8'
     resolution:
-      integrity: sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
+      integrity: sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==
   /normalize-url/5.3.0:
     dev: true
     engines:
@@ -6984,12 +6903,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
-  /nth-check/1.0.2:
+  /nth-check/2.0.0:
     dependencies:
       boolbase: 1.0.0
     dev: false
     resolution:
-      integrity: sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
+      integrity: sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==
   /number-is-nan/1.0.1:
     dev: true
     engines:
@@ -7021,9 +6940,11 @@ packages:
     resolution:
       integrity: sha1-fn2Fi3gb18mRpBupde04EnVOmYw=
   /object-inspect/1.9.0:
+    dev: true
     resolution:
       integrity: sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==
   /object-keys/1.1.1:
+    dev: true
     engines:
       node: '>= 0.4'
     resolution:
@@ -7042,20 +6963,11 @@ packages:
       define-properties: 1.1.3
       has-symbols: 1.0.1
       object-keys: 1.1.1
+    dev: true
     engines:
       node: '>= 0.4'
     resolution:
       integrity: sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==
-  /object.getownpropertydescriptors/2.1.1:
-    dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.1.3
-      es-abstract: 1.18.0-next.2
-    dev: false
-    engines:
-      node: '>= 0.8'
-    resolution:
-      integrity: sha512-6DtXgZ/lIZ9hqx4GtZETobXLR/ZLaa0aqV0kzbn80Rf8Z2e/XFnhA0I7p07N2wH8bBBltr2xQPi6sbKWAY2Eng==
   /object.pick/1.3.0:
     dependencies:
       isobject: 3.0.1
@@ -7070,6 +6982,7 @@ packages:
       define-properties: 1.1.3
       es-abstract: 1.18.0-next.2
       has: 1.0.3
+    dev: true
     engines:
       node: '>= 0.4'
     resolution:
@@ -7101,7 +7014,6 @@ packages:
     resolution:
       integrity: sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==
   /opencollective-postinstall/2.0.3:
-    dev: true
     hasBin: true
     resolution:
       integrity: sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
@@ -7289,6 +7201,7 @@ packages:
     dependencies:
       error-ex: 1.3.2
       json-parse-better-errors: 1.0.2
+    dev: true
     engines:
       node: '>=4'
     resolution:
@@ -7484,35 +7397,40 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
-  /postcss-calc/7.0.5:
+  /postcss-calc/8.0.0_postcss@8.2.4:
     dependencies:
-      postcss: 7.0.35
+      postcss: 8.2.4
       postcss-selector-parser: 6.0.4
       postcss-value-parser: 4.1.0
     dev: false
+    peerDependencies:
+      postcss: ^8.2.2
     resolution:
-      integrity: sha512-1tKHutbGtLtEZF6PT4JSihCHfIVldU72mZ8SdZHIYriIZ9fh9k9aWSppaT8rHsyI3dX+KSR+W+Ix9BMY3AODrg==
-  /postcss-colormin/4.0.3:
+      integrity: sha512-5NglwDrcbiy8XXfPM11F3HeC6hoT9W7GUH/Zi5U/p7u3Irv4rHhdDcIZwG0llHXV4ftsBjpfWMXAnXNl4lnt8g==
+  /postcss-colormin/5.0.0_postcss@8.2.4:
     dependencies:
       browserslist: 4.16.1
       color: 3.1.3
-      has: 1.0.3
-      postcss: 7.0.35
-      postcss-value-parser: 3.3.1
+      postcss: 8.2.4
+      postcss-value-parser: 4.1.0
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-WyQFAdDZpExQh32j0U0feWisZ0dmOtPl44qYmJKkq9xFWY3p+4qnRzCHeNrkeRhwPHz9bQ3mo0/yVkaply0MNw==
-  /postcss-convert-values/4.0.1:
+      integrity: sha512-Yt84+5V6CgS/AhK7d7MA58vG8dSZ7+ytlRtWLaQhag3HXOncTfmYpuUOX4cDoXjvLfw1sHRCHMiBjYhc35CymQ==
+  /postcss-convert-values/5.0.0_postcss@8.2.4:
     dependencies:
-      postcss: 7.0.35
-      postcss-value-parser: 3.3.1
+      postcss: 8.2.4
+      postcss-value-parser: 4.1.0
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-Kisdo1y77KUC0Jmn0OXU/COOJbzM8cImvw1ZFsBgBgMgb1iL23Zs/LXRe3r+EZqM3vGYKdQ2YJVQ5VkJI+zEJQ==
+      integrity: sha512-V5kmYm4xoBAjNs+eHY/6XzXJkkGeg4kwNf2ocfqhLb1WBPEa4oaSmoi1fnVO7Dkblqvus9h+AenDvhCKUCK7uQ==
   /postcss-custom-properties/11.0.0_postcss@8.2.4:
     dependencies:
       postcss: 8.2.4
@@ -7524,106 +7442,125 @@ packages:
       postcss: ^8.1.0
     resolution:
       integrity: sha512-Fhnx/QLt+CTt23A/KKVx1anZD9nmVpOxKCKv5owWacMoOsBXFhMAD6SZYbmPMH4nHdIeMUnWOvLZnlY4niS0sA==
-  /postcss-discard-comments/4.0.2:
+  /postcss-discard-comments/5.0.0_postcss@8.2.4:
     dependencies:
-      postcss: 7.0.35
+      postcss: 8.2.4
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-RJutN259iuRf3IW7GZyLM5Sw4GLTOH8FmsXBnv8Ab/Tc2k4SR4qbV4DNbyyY4+Sjo362SyDmW2DQ7lBSChrpkg==
-  /postcss-discard-duplicates/4.0.2:
+      integrity: sha512-Umig6Gxs8m20RihiXY6QkePd6mp4FxkA1Dg+f/Kd6uw0gEMfKRjDeQOyFkLibexbJJGHpE3lrN/Q0R9SMrUMbQ==
+  /postcss-discard-duplicates/5.0.0_postcss@8.2.4:
     dependencies:
-      postcss: 7.0.35
+      postcss: 8.2.4
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-ZNQfR1gPNAiXZhgENFfEglF93pciw0WxMkJeVmw8eF+JZBbMD7jp6C67GqJAXVZP2BWbOztKfbsdmMp/k8c6oQ==
-  /postcss-discard-empty/4.0.1:
+      integrity: sha512-vEJJ+Y3pFUnO1FyCBA6PSisGjHtnphL3V6GsNvkASq/VkP3OX5/No5RYXXLxHa2QegStNzg6HYrYdo71uR4caQ==
+  /postcss-discard-empty/5.0.0_postcss@8.2.4:
     dependencies:
-      postcss: 7.0.35
+      postcss: 8.2.4
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-B9miTzbznhDjTfjvipfHoqbWKwd0Mj+/fL5s1QOz06wufguil+Xheo4XpOnc4NqKYBCNqqEzgPv2aPBIJLox0w==
-  /postcss-discard-overridden/4.0.1:
+      integrity: sha512-+wigy099Y1xZxG36WG5L1f2zeH1oicntkJEW4TDIqKKDO2g9XVB3OhoiHTu08rDEjLnbcab4rw0BAccwi2VjiQ==
+  /postcss-discard-overridden/5.0.0_postcss@8.2.4:
     dependencies:
-      postcss: 7.0.35
+      postcss: 8.2.4
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-IYY2bEDD7g1XM1IDEsUT4//iEYCxAmP5oDSFMVU/JVvT7gh+l4fmjciLqGgwjdWpQIdb0Che2VX00QObS5+cTg==
-  /postcss-merge-longhand/4.0.11:
+      integrity: sha512-hybnScTaZM2iEA6kzVQ6Spozy7kVdLw+lGw8hftLlBEzt93uzXoltkYp9u0tI8xbfhxDLTOOzHsHQCkYdmzRUg==
+  /postcss-merge-longhand/5.0.0_postcss@8.2.4:
     dependencies:
-      css-color-names: 0.0.4
-      postcss: 7.0.35
-      postcss-value-parser: 3.3.1
-      stylehacks: 4.0.3
+      css-color-names: 1.0.1
+      postcss: 8.2.4
+      postcss-value-parser: 4.1.0
+      stylehacks: 5.0.0_postcss@8.2.4
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-alx/zmoeXvJjp7L4mxEMjh8lxVlDFX1gqWHzaaQewwMZiVhLo42TEClKaeHbRf6J7j82ZOdTJ808RtN0ZOZwvw==
-  /postcss-merge-rules/4.0.3:
+      integrity: sha512-VZNFA40K8BYHzJNA6jHPdg1Nofsz/nK5Dkszrcb5IgWcLroSBZOD6I/iNQzpejSU/3XwpOiZNaYAdBV4KcvxWA==
+  /postcss-merge-rules/5.0.0_postcss@8.2.4:
     dependencies:
       browserslist: 4.16.1
       caniuse-api: 3.0.0
-      cssnano-util-same-parent: 4.0.1
-      postcss: 7.0.35
-      postcss-selector-parser: 3.1.2
+      cssnano-utils: 2.0.0_postcss@8.2.4
+      postcss: 8.2.4
+      postcss-selector-parser: 6.0.4
       vendors: 1.0.4
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-U7e3r1SbvYzO0Jr3UT/zKBVgYYyhAz0aitvGIYOYK5CPmkNih+WDSsS5tvPrJ8YMQYlEMvsZIiqmn7HdFUaeEQ==
-  /postcss-minify-font-values/4.0.2:
+      integrity: sha512-TfsXbKjNYCGfUPEXGIGPySnMiJbdS+3gcVeV8gwmJP4RajyKZHW8E0FYDL1WmggTj3hi+m+WUCAvqRpX2ut4Kg==
+  /postcss-minify-font-values/5.0.0_postcss@8.2.4:
     dependencies:
-      postcss: 7.0.35
-      postcss-value-parser: 3.3.1
+      postcss: 8.2.4
+      postcss-value-parser: 4.1.0
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-j85oO6OnRU9zPf04+PZv1LYIYOprWm6IA6zkXkrJXyRveDEuQggG6tvoy8ir8ZwjLxLuGfNkCZEQG7zan+Hbtg==
-  /postcss-minify-gradients/4.0.2:
+      integrity: sha512-zi2JhFaMOcIaNxhndX5uhsqSY1rexKDp23wV8EOmC9XERqzLbHsoRye3aYF716Zm+hkcR4loqKDt8LZlmihwAg==
+  /postcss-minify-gradients/5.0.0_postcss@8.2.4:
     dependencies:
-      cssnano-util-get-arguments: 4.0.0
+      cssnano-utils: 2.0.0_postcss@8.2.4
       is-color-stop: 1.1.0
-      postcss: 7.0.35
-      postcss-value-parser: 3.3.1
+      postcss: 8.2.4
+      postcss-value-parser: 4.1.0
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-qKPfwlONdcf/AndP1U8SJ/uzIJtowHlMaSioKzebAXSG4iJthlWC9iSWznQcX4f66gIWX44RSA841HTHj3wK+Q==
-  /postcss-minify-params/4.0.2:
+      integrity: sha512-/jPtNgs6JySMwgsE5dPOq8a2xEopWTW3RyqoB9fLqxgR+mDUNLSi7joKd+N1z7FXWgVkc4l/dEBMXHgNAaUbvg==
+  /postcss-minify-params/5.0.0_postcss@8.2.4:
     dependencies:
       alphanum-sort: 1.0.2
       browserslist: 4.16.1
-      cssnano-util-get-arguments: 4.0.0
-      postcss: 7.0.35
-      postcss-value-parser: 3.3.1
+      cssnano-utils: 2.0.0_postcss@8.2.4
+      postcss: 8.2.4
+      postcss-value-parser: 4.1.0
       uniqs: 2.0.0
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-G7eWyzEx0xL4/wiBBJxJOz48zAKV2WG3iZOqVhPet/9geefm/Px5uo1fzlHu+DOjT+m0Mmiz3jkQzVHe6wxAWg==
-  /postcss-minify-selectors/4.0.2:
+      integrity: sha512-KvZYIxTPBVKjdd+XgObq9A+Sfv8lMkXTpbZTsjhr42XbfWIeLaTItMlygsDWfjArEc3muUfDaUFgNSeDiJ5jug==
+  /postcss-minify-selectors/5.0.0_postcss@8.2.4:
     dependencies:
       alphanum-sort: 1.0.2
-      has: 1.0.3
-      postcss: 7.0.35
+      postcss: 8.2.4
       postcss-selector-parser: 3.1.2
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-D5S1iViljXBj9kflQo4YutWnJmwm8VvIsU1GeXJGiG9j8CIg9zs4voPMdQDUmIxetUOh60VilsNzCiAFTOqu3g==
+      integrity: sha512-cEM0O0eWwFIvmo6nfB0lH0vO/XFwgqIvymODbfPXZ1gTA3i76FKnb7TGUrEpiTxaXH6tgYQ6DcTHwRiRS+YQLQ==
   /postcss-modules-extract-imports/3.0.0_postcss@8.2.4:
     dependencies:
       postcss: 8.2.4
@@ -7669,128 +7606,146 @@ packages:
       postcss: ^8.1.0
     resolution:
       integrity: sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==
-  /postcss-normalize-charset/4.0.1:
+  /postcss-normalize-charset/5.0.0_postcss@8.2.4:
     dependencies:
-      postcss: 7.0.35
+      postcss: 8.2.4
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-gMXCrrlWh6G27U0hF3vNvR3w8I1s2wOBILvA87iNXaPvSNo5uZAMYsZG7XjCUf1eVxuPfyL4TJ7++SGZLc9A3g==
-  /postcss-normalize-display-values/4.0.2:
+      integrity: sha512-pqsCkgo9KmQP0ew6DqSA+uP9YN6EfsW20pQ3JU5JoQge09Z6Too4qU0TNDsTNWuEaP8SWsMp+19l15210MsDZQ==
+  /postcss-normalize-display-values/5.0.0_postcss@8.2.4:
     dependencies:
-      cssnano-util-get-match: 4.0.0
-      postcss: 7.0.35
-      postcss-value-parser: 3.3.1
+      cssnano-utils: 2.0.0_postcss@8.2.4
+      postcss: 8.2.4
+      postcss-value-parser: 4.1.0
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-3F2jcsaMW7+VtRMAqf/3m4cPFhPD3EFRgNs18u+k3lTJJlVe7d0YPO+bnwqo2xg8YiRpDXJI2u8A0wqJxMsQuQ==
-  /postcss-normalize-positions/4.0.2:
+      integrity: sha512-t4f2d//gH1f7Ns0Jq3eNdnWuPT7TeLuISZ6RQx4j8gpl5XrhkdshdNcOnlrEK48YU6Tcb6jqK7dorME3N4oOGA==
+  /postcss-normalize-positions/5.0.0_postcss@8.2.4:
     dependencies:
-      cssnano-util-get-arguments: 4.0.0
-      has: 1.0.3
-      postcss: 7.0.35
-      postcss-value-parser: 3.3.1
+      postcss: 8.2.4
+      postcss-value-parser: 4.1.0
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-Dlf3/9AxpxE+NF1fJxYDeggi5WwV35MXGFnnoccP/9qDtFrTArZ0D0R+iKcg5WsUd8nUYMIl8yXDCtcrT8JrdA==
-  /postcss-normalize-repeat-style/4.0.2:
+      integrity: sha512-0o6/qU5ky74X/eWYj/tv4iiKCm3YqJnrhmVADpIMNXxzFZywsSQxl8F7cKs8jQEtF3VrJBgcDHTexZy1zgDoYg==
+  /postcss-normalize-repeat-style/5.0.0_postcss@8.2.4:
     dependencies:
-      cssnano-util-get-arguments: 4.0.0
-      cssnano-util-get-match: 4.0.0
-      postcss: 7.0.35
-      postcss-value-parser: 3.3.1
+      cssnano-utils: 2.0.0_postcss@8.2.4
+      postcss: 8.2.4
+      postcss-value-parser: 4.1.0
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-qvigdYYMpSuoFs3Is/f5nHdRLJN/ITA7huIoCyqqENJe9PvPmLhNLMu7QTjPdtnVf6OcYYO5SHonx4+fbJE1+Q==
-  /postcss-normalize-string/4.0.2:
+      integrity: sha512-KRT14JbrXKcFMYuc4q7lh8lvv8u22wLyMrq+UpHKLtbx2H/LOjvWXYdoDxmNrrrJzomAWL+ViEXr48/IhSUJnQ==
+  /postcss-normalize-string/5.0.0_postcss@8.2.4:
     dependencies:
-      has: 1.0.3
-      postcss: 7.0.35
-      postcss-value-parser: 3.3.1
+      postcss: 8.2.4
+      postcss-value-parser: 4.1.0
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-RrERod97Dnwqq49WNz8qo66ps0swYZDSb6rM57kN2J+aoyEAJfZ6bMx0sx/F9TIEX0xthPGCmeyiam/jXif0eA==
-  /postcss-normalize-timing-functions/4.0.2:
+      integrity: sha512-wSO4pf7GNcDZpmelREWYADF1+XZWrAcbFLQCOqoE92ZwYgaP/RLumkUTaamEzdT2YKRZAH8eLLKGWotU/7FNPw==
+  /postcss-normalize-timing-functions/5.0.0_postcss@8.2.4:
     dependencies:
-      cssnano-util-get-match: 4.0.0
-      postcss: 7.0.35
-      postcss-value-parser: 3.3.1
+      cssnano-utils: 2.0.0_postcss@8.2.4
+      postcss: 8.2.4
+      postcss-value-parser: 4.1.0
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-acwJY95edP762e++00Ehq9L4sZCEcOPyaHwoaFOhIwWCDfik6YvqsYNxckee65JHLKzuNSSmAdxwD2Cud1Z54A==
-  /postcss-normalize-unicode/4.0.1:
+      integrity: sha512-TwPaDX+wl9wO3MUm23lzGmOzGCGKnpk+rSDgzB2INpakD5dgWR3L6bJq1P1LQYzBAvz8fRIj2NWdnZdV4EV98Q==
+  /postcss-normalize-unicode/5.0.0_postcss@8.2.4:
     dependencies:
       browserslist: 4.16.1
-      postcss: 7.0.35
-      postcss-value-parser: 3.3.1
+      postcss: 8.2.4
+      postcss-value-parser: 4.1.0
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-od18Uq2wCYn+vZ/qCOeutvHjB5jm57ToxRaMeNuf0nWVHaP9Hua56QyMF6fs/4FSUnVIw0CBPsU0K4LnBPwYwg==
-  /postcss-normalize-url/4.0.1:
+      integrity: sha512-2CpVoz/67rXU5s9tsPZDxG1YGS9OFHwoY9gsLAzrURrCxTAb0H7Vp87/62LvVPgRWTa5ZmvgmqTp2rL8tlm72A==
+  /postcss-normalize-url/5.0.0_postcss@8.2.4:
     dependencies:
-      is-absolute-url: 2.1.0
-      normalize-url: 3.3.0
-      postcss: 7.0.35
-      postcss-value-parser: 3.3.1
+      is-absolute-url: 3.0.3
+      normalize-url: 4.5.0
+      postcss: 8.2.4
+      postcss-value-parser: 4.1.0
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-p5oVaF4+IHwu7VpMan/SSpmpYxcJMtkGppYf0VbdH5B6hN8YNmVyJLuY9FmLQTzY3fag5ESUUHDqM+heid0UVA==
-  /postcss-normalize-whitespace/4.0.2:
+      integrity: sha512-ICDaGFBqLgA3dlrCIRuhblLl80D13YtgEV9NJPTYJtgR72vu61KgxAHv+z/lKMs1EbwfSQa3ALjOFLSmXiE34A==
+  /postcss-normalize-whitespace/5.0.0_postcss@8.2.4:
     dependencies:
-      postcss: 7.0.35
-      postcss-value-parser: 3.3.1
+      postcss: 8.2.4
+      postcss-value-parser: 4.1.0
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-tO8QIgrsI3p95r8fyqKV+ufKlSHh9hMJqACqbv2XknufqEDhDvbguXGBBqxw9nsQoXWf0qOqppziKJKHMD4GtA==
-  /postcss-ordered-values/4.1.2:
+      integrity: sha512-KRnxQvQAVkJfaeXSz7JlnD9nBN9sFZF9lrk9452Q2uRoqrRSkinqifF8Iex7wZGei2DZVG/qpmDFDmRvbNAOGA==
+  /postcss-ordered-values/5.0.0_postcss@8.2.4:
     dependencies:
-      cssnano-util-get-arguments: 4.0.0
-      postcss: 7.0.35
-      postcss-value-parser: 3.3.1
+      cssnano-utils: 2.0.0_postcss@8.2.4
+      postcss: 8.2.4
+      postcss-value-parser: 4.1.0
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-2fCObh5UanxvSxeXrtLtlwVThBvHn6MQcu4ksNT2tsaV2Fg76R2CV98W7wNSlX+5/pFwEyaDwKLLoEV7uRybAw==
-  /postcss-reduce-initial/4.0.3:
+      integrity: sha512-dPr+SRObiHueCIc4IUaG0aOGQmYkuNu50wQvdXTGKy+rzi2mjmPsbeDsheLk5WPb9Zyf2tp8E+I+h40cnivm6g==
+  /postcss-reduce-initial/5.0.0_postcss@8.2.4:
     dependencies:
       browserslist: 4.16.1
       caniuse-api: 3.0.0
-      has: 1.0.3
-      postcss: 7.0.35
+      postcss: 8.2.4
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-gKWmR5aUulSjbzOfD9AlJiHCGH6AEVLaM0AV+aSioxUDd16qXP1PCh8d1/BGVvpdWn8k/HiK7n6TjeoXN1F7DA==
-  /postcss-reduce-transforms/4.0.2:
+      integrity: sha512-wR6pXUaFbSMG1oCKx8pKVA+rnSXCHlca5jMrlmkmif+uig0HNUTV9oGN5kjKsM3mATQAldv2PF9Tbl2vqLFjnA==
+  /postcss-reduce-transforms/5.0.0_postcss@8.2.4:
     dependencies:
-      cssnano-util-get-match: 4.0.0
-      has: 1.0.3
-      postcss: 7.0.35
-      postcss-value-parser: 3.3.1
+      cssnano-utils: 2.0.0_postcss@8.2.4
+      postcss: 8.2.4
+      postcss-value-parser: 4.1.0
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-EEVig1Q2QJ4ELpJXMZR8Vt5DQx8/mo+dGWSR7vWXqcob2gQLyQGsionYcGKATXvQzMPn6DSN1vTN7yFximdIAg==
+      integrity: sha512-iHdGODW4YzM3WjVecBhPQt6fpJC4lGQZxJKjkBNHpp2b8dzmvj0ogKThqya+IRodQEFzjfXgYeESkf172FH5Lw==
   /postcss-selector-parser/3.1.2:
     dependencies:
       dot-prop: 5.3.0
@@ -7812,31 +7767,31 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==
-  /postcss-svgo/4.0.2:
+  /postcss-svgo/5.0.0_postcss@8.2.4:
     dependencies:
-      is-svg: 3.0.0
-      postcss: 7.0.35
-      postcss-value-parser: 3.3.1
-      svgo: 1.3.2
+      postcss: 8.2.4
+      postcss-value-parser: 4.1.0
+      svgo: 2.3.0
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-C6wyjo3VwFm0QgBy+Fu7gCYOkCmgmClghO+pjcxvrcBKtiKt0uCF+hvbMO1fyv5BMImRK90SMb+dwUnfbGd+jw==
-  /postcss-unique-selectors/4.0.1:
+      integrity: sha512-M3/VS4sFI1Yp9g0bPL+xzzCNz5iLdRUztoFaugMit5a8sMfkVzzhwqbsOlD8IFFymCdJDmXmh31waYHWw1K4BA==
+  /postcss-unique-selectors/5.0.0_postcss@8.2.4:
     dependencies:
       alphanum-sort: 1.0.2
-      postcss: 7.0.35
+      postcss: 8.2.4
+      postcss-selector-parser: 6.0.4
       uniqs: 2.0.0
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-+JanVaryLo9QwZjKrmJgkI4Fn8SBgRO6WXQBJi7KiAVPlmxikB5Jzc4EvXMT2H0/m0RjrVVm9rGNhZddm/8Spg==
-  /postcss-value-parser/3.3.1:
-    dev: false
-    resolution:
-      integrity: sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
+      integrity: sha512-o9l4pF8SRn7aCMTmzb/kNv/kjV7wPZpZ8Nlb1Gq8v/Qvw969K1wanz1RVA0ehHzWe9+wHXaC2DvZlak/gdMJ5w==
   /postcss-value-parser/4.1.0:
     resolution:
       integrity: sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
@@ -7946,6 +7901,7 @@ packages:
     resolution:
       integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
   /q/1.5.1:
+    dev: true
     engines:
       node: '>=0.6.0'
       teleport: '>=0.2.0'
@@ -8318,12 +8274,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==
-  /resolve-from/3.0.0:
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha1-six699nWiBvItuZTM17rywoYh0g=
   /resolve-from/4.0.0:
     engines:
       node: '>=4'
@@ -8554,6 +8504,7 @@ packages:
     resolution:
       integrity: sha512-kU1yJ5zUAmPxr7f3q0YXTAd1oZjSR1g3tYyv+xu0HZSl5JiNOaE987eiz7wCUvbm4I9fGWGU2TgApTtcP4GMNQ==
   /sax/1.2.4:
+    dev: true
     resolution:
       integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
   /saxes/5.0.1:
@@ -8958,6 +8909,7 @@ packages:
     resolution:
       integrity: sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==
   /sprintf-js/1.0.3:
+    dev: true
     resolution:
       integrity: sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
   /sshpk/1.16.1:
@@ -9084,12 +9036,14 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
+    dev: true
     resolution:
       integrity: sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==
   /string.prototype.trimstart/1.0.3:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
+    dev: true
     resolution:
       integrity: sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==
   /string_decoder/1.1.1:
@@ -9213,16 +9167,18 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-IrD6OkE4WzO+PzMVUbu4N/oM164=
-  /stylehacks/4.0.3:
+  /stylehacks/5.0.0_postcss@8.2.4:
     dependencies:
       browserslist: 4.16.1
-      postcss: 7.0.35
-      postcss-selector-parser: 3.1.2
+      postcss: 8.2.4
+      postcss-selector-parser: 6.0.4
     dev: false
     engines:
-      node: '>=6.9.0'
+      node: ^10 || ^12 || >=14.0
+    peerDependencies:
+      postcss: ^8.2.1
     resolution:
-      integrity: sha512-7GlLk9JwlElY4Y6a/rmbH2MhVlTyVmiJd1PfTCqFaIBEGMYNsrO/v3SeGTdhBThLg4Z+NbOk/qFMwCa+J+3p/g==
+      integrity: sha512-QOWm6XivDLb+fqffTZP8jrmPmPITVChl2KCY2R05nsCWwLi3VGhCdVc3IVGNwd1zzTt1jPd67zIKjpQfxzQZeA==
   /stylus/0.54.8:
     dependencies:
       css-parse: 2.0.0
@@ -9268,7 +9224,6 @@ packages:
   /supports-color/7.2.0:
     dependencies:
       has-flag: 4.0.0
-    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -9282,27 +9237,21 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==
-  /svgo/1.3.2:
+  /svgo/2.3.0:
     dependencies:
-      chalk: 2.4.2
-      coa: 2.0.2
-      css-select: 2.1.0
-      css-select-base-adapter: 0.1.1
-      css-tree: 1.0.0-alpha.37
+      '@trysound/sax': 0.1.1
+      chalk: 4.1.0
+      commander: 7.2.0
+      css-select: 3.1.2
+      css-tree: 1.1.2
       csso: 4.2.0
-      js-yaml: 3.14.1
-      mkdirp: 0.5.5
-      object.values: 1.1.2
-      sax: 1.2.4
       stable: 0.1.8
-      unquote: 1.1.1
-      util.promisify: 1.0.1
     dev: false
     engines:
-      node: '>=4.0.0'
+      node: '>=10.13.0'
     hasBin: true
     resolution:
-      integrity: sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==
+      integrity: sha512-fz4IKjNO6HDPgIQxu4IxwtubtbSfGEAJUq/IXyTPIkGhWck/faiiwfkvsB8LnBkKLvSoyNNIY6d13lZprJMc9Q==
   /symbol-tree/3.2.4:
     dev: true
     resolution:
@@ -9762,10 +9711,6 @@ packages:
       node: '>= 10.0.0'
     resolution:
       integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
-  /unquote/1.1.1:
-    dev: false
-    resolution:
-      integrity: sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=
   /unset-value/1.0.0:
     dependencies:
       has-value: 0.3.1
@@ -9799,15 +9744,6 @@ packages:
   /util-deprecate/1.0.2:
     resolution:
       integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
-  /util.promisify/1.0.1:
-    dependencies:
-      define-properties: 1.1.3
-      es-abstract: 1.17.7
-      has-symbols: 1.0.1
-      object.getownpropertydescriptors: 2.1.1
-    dev: false
-    resolution:
-      integrity: sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==
   /uuid/3.4.0:
     dev: true
     hasBin: true
@@ -10174,7 +10110,7 @@ specifiers:
   autoprefixer: ^10.2.4
   builtin-modules: ^3.2.0
   cosmiconfig: ^7.0.0
-  cssnano: ^4.1.10
+  cssnano: ^5.0.0
   eslint: ^7.18.0
   eslint-config-prettier: ^7.2.0
   eslint-import-resolver-node: ^0.3.4


### PR DESCRIPTION
Hello, I want to update cssnano [v5.0.0](https://github.com/cssnano/cssnano/releases/tag/cssnano%405.0.0) since it's fully compatible with PostCSS v8. It has been release a couple hours ago, but it was in rc for a while already.