### PR TITLE
build: Bump package version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 ### 🎨 Universal [Rollup](https://github.com/rollup/rollup) plugin for styles:
 
 - [PostCSS](https://github.com/postcss/postcss)
-
 - [Sass](https://github.com/sass/dart-sass)
 - [Less](https://github.com/less/less.js)
 - [Stylus](https://github.com/stylus/stylus)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 ### 🎨 Universal [Rollup](https://github.com/rollup/rollup) plugin for styles:
 
 - [PostCSS](https://github.com/postcss/postcss)
+
 - [Sass](https://github.com/sass/dart-sass)
 - [Less](https://github.com/less/less.js)
 - [Stylus](https://github.com/stylus/stylus)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-styles",
-  "version": "3.14.1",
+  "version": "3.15.1",
   "description": "Universal Rollup plugin for styles: PostCSS, Sass, Less, Stylus and more",
   "keywords": [
     "rollup",


### PR DESCRIPTION
Bumping the package version.  A PR was completed to bump the version of css-nano that is used but the package version wasn't bumped so it's still showing the vulnerability