### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@rollup/pluginutils": "^4.1.0",
     "@types/cssnano": "^4.0.0",
     "cosmiconfig": "^7.0.0",
-    "cssnano": "^5.0.0",
+    "cssnano": "^5.0.6",
     "fs-extra": "^9.1.0",
     "icss-utils": "^5.1.0",
     "mime-types": "^2.1.28",


### PR DESCRIPTION
```
npm audit
```
  High            Regular Expression Denial of Service

  Package         normalize-url

  Patched in      >=4.5.1 <5.0.0 || >=5.3.1 <6.0.0 || >=6.0.1

  Dependency of   rollup-plugin-styles [dev]

  Path            rollup-plugin-styles > cssnano > cssnano-preset-default >
                  postcss-normalize-url > normalize-url

  More info       https://npmjs.com/advisories/1755

This update will fix vulnerability