### PR TITLE
make some improvements to CSS modules

### DIFF
--- a/src/loaders/postcss/index.ts
+++ b/src/loaders/postcss/index.ts
@@ -29,7 +29,11 @@ function getClassNameDefault(name: string): string {
   return id;
 }
 
-function ensureAutoModules(am: PostCSSLoaderOptions["autoModules"], id: string): boolean {
+function ensureAutoModules(
+  am: PostCSSLoaderOptions["autoModules"] | undefined,
+  id: string,
+): boolean {
+  if (am === undefined) return false;
   if (typeof am === "function") return am(id);
   if (am instanceof RegExp) return am.test(id);
   return am && /\.module\.[A-Za-z]+$/.test(id);
@@ -46,7 +50,9 @@ const loader: Loader<PostCSSLoaderOptions> = {
     const config = await loadConfig(this.id, options.config);
     const plugins: AcceptedPlugin[] = [];
     const autoModules = ensureAutoModules(options.autoModules, this.id);
-    const supportModules = Boolean(options.modules || autoModules);
+    const supportModules = Boolean(
+      (options.modules && ensureAutoModules(options.modules.include, this.id)) || autoModules,
+    );
     const modulesExports: Record<string, string> = {};
 
     const postcssOpts: PostCSSOptions = {
@@ -114,7 +120,7 @@ const loader: Loader<PostCSSLoaderOptions> = {
           break;
       }
 
-    map = mm((res.map?.toJSON() as unknown) as RawSourceMap)
+    map = mm(res.map?.toJSON() as unknown as RawSourceMap)
       .resolve(path.dirname(postcssOpts.to))
       .toString();
 

--- a/src/loaders/postcss/modules/generate.ts
+++ b/src/loaders/postcss/modules/generate.ts
@@ -18,7 +18,7 @@ export default (placeholder = "[name]_[local]__[hash:8]") => (
   return makeLegalIdentifier(
     placeholder
       .replace("[dir]", path.basename(dir))
-      .replace("[name]", name)
+      .replace("[name]", name.replace(/\.module$/, ""))
       .replace("[local]", local)
       .replace(hashRe, hashLen ? hash.slice(0, hashLen) : hash),
   );

--- a/src/loaders/postcss/modules/index.ts
+++ b/src/loaders/postcss/modules/index.ts
@@ -27,6 +27,14 @@ export interface ModulesOptions {
    * @default "[name]_[local]__[hash:8]"
    */
   generateScopedName?: string | ((name: string, file: string, css: string) => string);
+  /**
+   * Files to include for [CSS Modules](https://github.com/css-modules/css-modules)
+   * for files named `[name].module.[ext]`
+   * (e.g. `foo.module.css`, `bar.module.stylus`),
+   * or pass your own function or regular expression
+   * @default false
+   */
+  include?: import("../../../types").Options["autoModules"];
 }
 
 export default (options: ModulesOptions): (Plugin | Processor)[] => {


### PR DESCRIPTION
- remove .module from `[name]` placeholder
	- The class names would come out like myFile_module_className__hash, when they should look like myFile_className__hash
- feat: add modules.include option
	- `options.modules` overrides the regex/function from `options.autoModules` and makes everything a CSS module when I only want to change the scoped name.
	- I probably didn't approach this in the best way, but modifying existing options could create a breaking change.