### PR TITLE
chore: update husky usage for current version

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+pnpm t -- --no-cache && lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+pnpm t -- --no-cache && lint-staged

--- a/husky.config.js
+++ b/husky.config.js
@@ -1,8 +1,0 @@
-const tasks = arr => arr.join(" && ");
-
-module.exports = {
-  hooks: {
-    "pre-commit": tasks(["pnpm t -- --no-cache", "lint-staged"]),
-    "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-  },
-};

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "prepublishOnly": "npm run build",
     "release": "semantic-release",
     "pretest": "npm run lint",
-    "test": "jest"
+    "test": "jest",
+    "prepare": "husky install"
   },
   "dependencies": {
     "@rollup/pluginutils": "^4.1.2",


### PR DESCRIPTION
A recent PR moved to `husky@7.0` without updating the usage to that version.

This doesn't address the other issues that the PR created by updating to all latest versions without correcting consumption of those packages, but hopefully it helps surface those issues more readily.