### PR TITLE
build(deps): remove unnecessary @types/cssnano

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
   },
   "dependencies": {
     "@rollup/pluginutils": "^4.1.2",
-    "@types/cssnano": "^5.0.0",
     "cosmiconfig": "^7.0.1",
     "cssnano": "^5.0.16",
     "fs-extra": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,6 @@ specifiers:
   '@rollup/pluginutils': ^4.1.2
   '@semantic-release/changelog': ^6.0.1
   '@semantic-release/git': ^10.0.1
-  '@types/cssnano': ^5.0.0
   '@types/fs-extra': ^9.0.13
   '@types/jest': ^27.4.0
   '@types/mime-types': ^2.1.1
@@ -77,7 +76,6 @@ specifiers:
 
 dependencies:
   '@rollup/pluginutils': 4.1.2
-  '@types/cssnano': 5.0.0
   cosmiconfig: 7.0.1
   cssnano: 5.0.16_postcss@8.4.5
   fs-extra: 10.0.0
@@ -2212,12 +2210,6 @@ packages:
     dependencies:
       '@babel/types': 7.16.8
     dev: true
-
-  /@types/cssnano/5.0.0:
-    resolution: {integrity: sha512-z98V7ICNAojxj9YV9+Q8qV+F7fW0poLWJRjed9tu7KNdYzHwAvLOAsTMI8xWjkOY9yzO+HmMxRRixlIvRsZwXg==}
-    dependencies:
-      postcss: 8.4.5
-    dev: false
 
   /@types/estree/0.0.39:
     resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}


### PR DESCRIPTION
Because:

```
warning rollup-plugin-styles > @types/cssnano@5.1.0: This is a stub types definition. cssnano provides its own type definitions, so you do not need this installed.
```