### PR TITLE
feat: expose module metadata in `emit` mode

### DIFF
--- a/__tests__/__snapshots__/index.test.ts.snap
+++ b/__tests__/__snapshots__/index.test.ts.snap
@@ -2063,6 +2063,14 @@ exports[`code-splitting true: map 4`] = `"{\\"version\\":3,\\"sources\\":[\\"../
 
 exports[`code-splitting true: map 5`] = `"{\\"version\\":3,\\"sources\\":[\\"../../../../code-splitting/second.scss\\"],\\"names\\":[],\\"mappings\\":\\"AAAA;EACE,gBAAA;AACF\\",\\"file\\":\\"second-47b1938d.css\\",\\"sourcesContent\\":[\\".second {\\\\n  color: royalblue;\\\\n}\\\\n\\"]}"`;
 
+exports[`emit meta: js 1`] = `
+"var deps = [\\"./shared.css\\"];
+var modules_5a199c00 = {\\"main\\":\\"style_main shared_bold\\"};
+
+console.log(modules_5a199c00, deps);
+"
+`;
+
 exports[`emit sourcemap: js 1`] = `
 "import { css } from 'lit';
 

--- a/__tests__/fixtures/emit-with-modules/index.js
+++ b/__tests__/fixtures/emit-with-modules/index.js
@@ -1,0 +1,2 @@
+import style, { deps } from "./style.css";
+console.log(style, deps);

--- a/__tests__/fixtures/emit-with-modules/shared.css
+++ b/__tests__/fixtures/emit-with-modules/shared.css
@@ -1,0 +1,3 @@
+.bold {
+  font-weight: bold;
+}

--- a/__tests__/fixtures/emit-with-modules/style.css
+++ b/__tests__/fixtures/emit-with-modules/style.css
@@ -1,0 +1,4 @@
+.main {
+  display: flex;
+  composes: bold from "./shared.css";
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,6 +112,7 @@ export default (options: Options = {}): Plugin => {
         code: res.code,
         map: sourceMap && res.map ? res.map : { mappings: "" as const },
         moduleSideEffects: res.extracted ? true : null,
+        meta: { styles: res.meta },
       };
     },
 

--- a/src/loaders/postcss/icss/index.ts
+++ b/src/loaders/postcss/icss/index.ts
@@ -44,6 +44,14 @@ const plugin: PluginCreator<InteroperableCSSOptions> = (options = {}) => {
           export: { [k]: replaceValueSymbols(v, imports) },
         });
       }
+
+      for (const key of Object.keys(icssImports)) {
+        res.messages.push({
+          plugin: name,
+          type: "icss-dependency",
+          import: key,
+        });
+      }
     },
   };
 };

--- a/src/loaders/types.ts
+++ b/src/loaders/types.ts
@@ -61,6 +61,8 @@ export interface Payload {
   map?: string;
   /** Extracted data */
   extracted?: Extracted;
+  /** Additional metadata exposed to other Rollup plugins */
+  meta?: rollup.CustomPluginOptions;
 }
 
 /** Options for sourcemaps */


### PR DESCRIPTION
## Background

The Ember.js community is moving toward adopting a [set of conventional Rollup plugins](https://github.com/embroider-build/embroider/tree/main/packages/addon-dev) for its [v2 package format](https://emberjs.github.io/rfcs/0507-embroider-v2-package-format.html), which has libraries publish code with stylesheet imports intact so the end consuming application can make decisions about bundling strategy, tree shaking, etc.

In support of that, I've been looking at ways to process stylesheets in-place and emit the results as assets in the final output, more or less as described in #200.

I've got a plugin `rollup-plugin-preserve-css` in progress that, in general, works nicely with `rollup-plugin-styles`'s `emit` mode.

The only caveat is that when devs wish to enable CSS Modules, information about inter-module dependencies and exported class name mappings are lost.

## This Change

This PR has `rollup-plugin-styles` expose a list of ICSS dependencies, as well as the composed JS text of the module, as Rollup plugin metadata. This allows downstream plugins like `preserve-css` to consume that information and emit it in a way that preserves both the processed CSS and the necessary mappings.