### PR TITLE
feat: url publicPath and assetDir can be a function

### DIFF
--- a/src/loaders/postcss/url/index.ts
+++ b/src/loaders/postcss/url/index.ts
@@ -24,13 +24,13 @@ export interface UrlOptions {
    * Public Path for URLs in CSS files
    * @default "./"
    */
-  publicPath?: string | ((original: string, resolved: string) => string);
+  publicPath?: string | ((original: string, resolved: string, file: string) => string);
   /**
    * Directory path for outputted CSS assets,
    * which is not included into resulting URL
    * @default "."
    */
-  assetDir?: string | ((original: string, resolved: string) => string);
+  assetDir?: string | ((original: string, resolved: string, file: string) => string);
   /**
    * Enable/disable name generation with hash for outputted CSS assets
    * or provide your own placeholder with the following blocks:
@@ -190,12 +190,12 @@ const plugin: PluginCreator<UrlOptions> = (options = {}) => {
           node.type = "string";
           node.value =
             typeof publicPath === "function"
-              ? publicPath(node.value, resolvedPublicPath)
+              ? publicPath(node.value, resolvedPublicPath, file)
               : resolvedPublicPath;
 
           if (urlQuery) node.value += urlQuery;
           to = normalizePath(typeof assetDir === "string" ? assetDir : defaultAssetDir, to);
-          to = typeof assetDir === "function" ? assetDir(from, to) : to;
+          to = typeof assetDir === "function" ? assetDir(from, to, file) : to;
 
           res.messages.push({ plugin: name, type: "asset", to, source });
         }

--- a/src/loaders/postcss/url/index.ts
+++ b/src/loaders/postcss/url/index.ts
@@ -30,7 +30,7 @@ export interface UrlOptions {
    * which is not included into resulting URL
    * @default "."
    */
-  assetDir?: string;
+  assetDir?: string | ((original: string, resolved: string) => string);
   /**
    * Enable/disable name generation with hash for outputted CSS assets
    * or provide your own placeholder with the following blocks:
@@ -38,7 +38,6 @@ export interface UrlOptions {
    * - `[ext]`: The file extension without a leading dot, e.g. `png`.
    * - `[hash(:<num>)]`: A hash based on the name and content of the asset (with optional length).
    * - `[name]`: The file name of the asset excluding any extension.
-   * - `[dir]`: The file path of the asset.
    *
    * Forward slashes / can be used to place files in sub-directories.
    * @default "assets/[name]-[hash][extname]" ("assets/[name][extname]" if false)
@@ -188,8 +187,9 @@ const plugin: PluginCreator<UrlOptions> = (options = {}) => {
               : publicPath + (/[/\\]$/.test(publicPath) ? "" : "/") + path.basename(to);
 
           if (urlQuery) node.value += urlQuery;
+          to = typeof assetDir === "string" ? normalizePath(assetDir, to) : to;
+          to = typeof assetDir === "function" ? assetDir(from, to) : to;
 
-          to = normalizePath(assetDir, to);
           res.messages.push({ plugin: name, type: "asset", to, source });
         }
 

--- a/src/loaders/postcss/url/index.ts
+++ b/src/loaders/postcss/url/index.ts
@@ -24,7 +24,7 @@ export interface UrlOptions {
    * Public Path for URLs in CSS files
    * @default "./"
    */
-  publicPath?: string | ((original: string) => string);
+  publicPath?: string | ((original: string, resolved: string) => string);
   /**
    * Directory path for outputted CSS assets,
    * which is not included into resulting URL
@@ -57,9 +57,11 @@ export interface UrlOptions {
 }
 
 const plugin: PluginCreator<UrlOptions> = (options = {}) => {
+  const defaultpublicPath = "./";
+  const defaultAssetDir = ".";
   const inline = options.inline ?? false;
-  const publicPath = options.publicPath ?? "./";
-  const assetDir = options.assetDir ?? ".";
+  const publicPath = options.publicPath ?? defaultpublicPath;
+  const assetDir = options.assetDir ?? defaultAssetDir;
   const resolve = options.resolve ?? resolveDefault;
   const alias = options.alias ?? {};
   const placeholder =
@@ -180,14 +182,19 @@ const plugin: PluginCreator<UrlOptions> = (options = {}) => {
 
           usedNames.set(to, from);
 
+          const resolvedPublicPath =
+            typeof publicPath === "string"
+              ? publicPath + (/[/\\]$/.test(publicPath) ? "" : "/") + path.basename(to)
+              : `${defaultpublicPath}${path.basename(to)}`;
+
           node.type = "string";
           node.value =
             typeof publicPath === "function"
-              ? publicPath(node.value)
-              : publicPath + (/[/\\]$/.test(publicPath) ? "" : "/") + path.basename(to);
+              ? publicPath(node.value, resolvedPublicPath)
+              : resolvedPublicPath;
 
           if (urlQuery) node.value += urlQuery;
-          to = typeof assetDir === "string" ? normalizePath(assetDir, to) : to;
+          to = normalizePath(typeof assetDir === "string" ? assetDir : defaultAssetDir, to);
           to = typeof assetDir === "function" ? assetDir(from, to) : to;
 
           res.messages.push({ plugin: name, type: "asset", to, source });

--- a/src/loaders/postcss/url/index.ts
+++ b/src/loaders/postcss/url/index.ts
@@ -24,7 +24,7 @@ export interface UrlOptions {
    * Public Path for URLs in CSS files
    * @default "./"
    */
-  publicPath?: string;
+  publicPath?: string | ((original: string) => string);
   /**
    * Directory path for outputted CSS assets,
    * which is not included into resulting URL
@@ -38,6 +38,7 @@ export interface UrlOptions {
    * - `[ext]`: The file extension without a leading dot, e.g. `png`.
    * - `[hash(:<num>)]`: A hash based on the name and content of the asset (with optional length).
    * - `[name]`: The file name of the asset excluding any extension.
+   * - `[dir]`: The file path of the asset.
    *
    * Forward slashes / can be used to place files in sub-directories.
    * @default "assets/[name]-[hash][extname]" ("assets/[name][extname]" if false)
@@ -181,7 +182,11 @@ const plugin: PluginCreator<UrlOptions> = (options = {}) => {
           usedNames.set(to, from);
 
           node.type = "string";
-          node.value = publicPath + (/[/\\]$/.test(publicPath) ? "" : "/") + path.basename(to);
+          node.value =
+            typeof publicPath === "function"
+              ? publicPath(node.value)
+              : publicPath + (/[/\\]$/.test(publicPath) ? "" : "/") + path.basename(to);
+
           if (urlQuery) node.value += urlQuery;
 
           to = normalizePath(assetDir, to);


### PR DESCRIPTION
Good day!

I'm using `rollup-plugin-styles` with the rollup options `preserveModules` and `preserveModulesRoot`. In the resulting file structure I need to keep the original `publicPath` of the `url` asset and the asset path should also remain the same. To make this possible I've added the possibility to make the url `publicPath` and `assetDir` option a `function` which gives you the original paths and resolved paths and its up to the consumer whats returned.