### PR TITLE
fix: add nonce attribute to style tag

### DIFF
--- a/runtime/inject-css.js
+++ b/runtime/inject-css.js
@@ -32,6 +32,8 @@ export default function (css, options) {
         styleTag.setAttribute(k[i], options.attributes[k[i]]);
       }
     }
+    if (typeof __webpack_nonce__ !== "undefined")
+      styleTag.setAttribute("nonce", __webpack_nonce__);
     var pos = position === "prepend" ? "afterbegin" : "beforeend";
     container.insertAdjacentElement(pos, styleTag);
     return styleTag;


### PR DESCRIPTION
Get nonce attribute from `__webpack_nonce__` and set this attribute to style tag

fix: https://github.com/Anidetrix/rollup-plugin-styles/issues/215